### PR TITLE
Log less often; fix device; add q3, q5

### DIFF
--- a/main.py
+++ b/main.py
@@ -19,6 +19,7 @@ def _parse_args():
     parser.add_argument("--optimizer_tag", type=str, default="AdamW")
     # Experiment
     parser.add_argument("--log_npz", type=str, required=True)
+    parser.add_argument("--log_every", type=int, default=10)
     parser.add_argument("--seed", type=int, default=42)
     parser.add_argument("--device", type=str, default="cpu")
     args = parser.parse_args()
@@ -40,6 +41,7 @@ def main(args: argparse.Namespace):
     set_seed(args.seed)
     optimizer_type, optimizer_cfg = _get_optimizer_configs(args.optimizer_tag)
     logs = transformer_fraction(
+        args,
         fraction=args.training_fraction,
         modulus=args.prime,
         num_sum=args.num_sum,

--- a/main.py
+++ b/main.py
@@ -17,11 +17,13 @@ def _parse_args():
     parser.add_argument("--dropout", type=float, default=0)
     parser.add_argument("--noise_ratio", type=float, default=0)
     parser.add_argument("--optimizer_tag", type=str, default="AdamW")
+    parser.add_argument("--max_grad_norm", type=float, default=None)
     # Experiment
     parser.add_argument("--log_npz", type=str, required=True)
     parser.add_argument("--log_every", type=int, default=10)
     parser.add_argument("--seed", type=int, default=42)
     parser.add_argument("--device", type=str, default="cpu")
+    parser.add_argument("--perturb_ratio", type=float, default=0)
     args = parser.parse_args()
     return args
 

--- a/main.py
+++ b/main.py
@@ -33,6 +33,24 @@ def _get_optimizer_configs(tag: str):
             "betas": (0.9, 0.98),
             "weight_decay": 1.0,
         }
+    elif tag == "Adam":
+        type = torch.optim.Adam
+        cfg = {
+            "lr": 1e-3,
+            "betas": (0.9, 0.98),
+        }
+    elif tag == "Adam_lr0.3x":
+        type = torch.optim.Adam
+        cfg = {
+            "lr": 3e-4,
+            "betas": (0.9, 0.98),
+        }
+    elif tag == "Adam_lr3x":
+        type = torch.optim.Adam
+        cfg = {
+            "lr": 3e-3,
+            "betas": (0.9, 0.98),
+        }
     else:
         raise NotImplementedError
     return type, cfg

--- a/task_1/model_training.py
+++ b/task_1/model_training.py
@@ -18,6 +18,26 @@ def linear_warmup_schedule(warmup_steps):#学习率线性warm-up
             return 1.0
     return lr_lambda
 
+def perturb_dataset(dataset, args):
+    all_indices = dataset.indices
+    perturbed_indices = all_indices[:int(len(all_indices) * args.perturb_ratio)]
+    dataset.dataset.tensors[1][perturbed_indices] = (dataset.dataset.tensors[1][perturbed_indices] + torch.randint(high=args.prime, size=(len(perturbed_indices),), device=args.device)) % args.prime
+    return dataset
+
+def get_scale_logs(value_list):
+    l1_norm = 0.0
+    l2_norm = 0.0
+    max_norm = 0.0
+    for value in value_list:
+        l1_norm += torch.abs(value).sum().item()
+        l2_norm += torch.sqrt((value ** 2).sum()).item()
+        max_norm += torch.abs(value).max().item()
+    return {
+        "l1": l1_norm,
+        "l2": l2_norm,
+        "linf": max_norm,
+    }
+
 def transformer_fraction(args,fraction:float=0.5,modulus:int=31,num_sum:int=2,max_opt_times:int=50000,
                          dropout=0.1,noise_ratio:float=0.0,optim_class=torch.optim.AdamW,optim_params={}):
     device = args.device
@@ -29,6 +49,8 @@ def transformer_fraction(args,fraction:float=0.5,modulus:int=31,num_sum:int=2,ma
     max_epoches=int(max_opt_times/ceil(train_num/batch_size))
     #train_dataset,test_dataset=data_generation(device,fraction=fraction,MODULUS:int=31,num_sum:int=2)#生成训练集，测试集
     train_dataset,test_dataset=multi_data_generation(device,fraction=fraction,MODULUS=modulus,num_sum=num_sum)#生成训练集，测试集
+    if args.perturb_ratio > 0:
+        train_dataset = perturb_dataset(train_dataset, args)
     train_loader=DataLoader(train_dataset,batch_size=batch_size,shuffle=True)
     test_loader=DataLoader(test_dataset,batch_size=batch_size,shuffle=False)
     ce_loss=nn.CrossEntropyLoss()
@@ -37,7 +59,7 @@ def transformer_fraction(args,fraction:float=0.5,modulus:int=31,num_sum:int=2,ma
     scheduler=LambdaLR(optimizer,lr_lambda=linear_warmup_schedule(warmup_steps=10))#学习率管理
     iter=0
     logs = {}
-    for tag in ["train_loss", "train_acc", "val_loss", "val_acc", "step"]:
+    for tag in ["train_loss", "train_acc", "val_loss", "val_acc", "step", "wl1", "wl2", "wlinf", "gl1", "gl2", "glinf"]:
         logs[tag] = []
     for i in tqdm(range(max_epoches), total=max_epoches):
         for data,label in train_loader:
@@ -46,6 +68,15 @@ def transformer_fraction(args,fraction:float=0.5,modulus:int=31,num_sum:int=2,ma
             output=T_model(data)#[:,-1][:,-1]
             loss=ce_loss(output[:,-1].view(-1,modulus+2),label.view(-1))#[:,-1]
             loss.backward()
+            if args.max_grad_norm is not None:
+                nn.utils.clip_grad_norm_(T_model.parameters(), args.max_grad_norm)
+            if iter % args.log_every == 0:
+                grad_logs = get_scale_logs([param.grad for param in T_model.parameters()])
+                for key in ["l1", "l2", "linf"]:
+                    logs[f"g{key}"].append(grad_logs[key])
+                weight_logs = get_scale_logs([param for param in T_model.parameters()])
+                for key in ["l1", "l2", "linf"]:
+                    logs[f"w{key}"].append(weight_logs[key])
             optimizer.step()
             scheduler.step()
             if iter % args.log_every == 0:

--- a/task_1/model_training.py
+++ b/task_1/model_training.py
@@ -18,7 +18,7 @@ def linear_warmup_schedule(warmup_steps):#学习率线性warm-up
             return 1.0
     return lr_lambda
 
-def transformer_fraction(fraction:float=0.5,modulus:int=31,num_sum:int=2,max_opt_times:int=50000,
+def transformer_fraction(args,fraction:float=0.5,modulus:int=31,num_sum:int=2,max_opt_times:int=50000,
                          dropout=0.1,noise_ratio:float=0.0,optim_class=torch.optim.AdamW,optim_params={}):
     device = torch.device("mps" if torch.backends.mps.is_available() 
                         else "cuda" if torch.cuda.is_available() else "cpu")
@@ -38,7 +38,7 @@ def transformer_fraction(fraction:float=0.5,modulus:int=31,num_sum:int=2,max_opt
     scheduler=LambdaLR(optimizer,lr_lambda=linear_warmup_schedule(warmup_steps=10))#学习率管理
     iter=0
     logs = {}
-    for tag in ["train_loss", "train_acc", "val_loss", "val_acc"]:
+    for tag in ["train_loss", "train_acc", "val_loss", "val_acc", "step"]:
         logs[tag] = []
     for i in tqdm(range(max_epoches), total=max_epoches):
         for data,label in train_loader:
@@ -49,12 +49,13 @@ def transformer_fraction(fraction:float=0.5,modulus:int=31,num_sum:int=2,max_opt
             loss.backward()
             optimizer.step()
             scheduler.step()
-            logs["train_loss"].append(loss.item())
-            logs["train_acc"].append(cal_accuracy(output[:,-1],label)/label.size(-1))
-            #train_loss[iter],train_acc[iter]=loss_record(T_model,train_loader)#误差计算
-            val_loss, val_acc = loss_record(T_model,test_loader)
-            logs["val_loss"].append(val_loss.item() / valid_num)
-            logs["val_acc"].append(val_acc / valid_num)
+            if iter % args.log_every == 0:
+                val_loss, val_acc = loss_record(T_model,test_loader)
+                logs["train_loss"].append(loss.item())
+                logs["train_acc"].append(cal_accuracy(output[:,-1],label)/label.size(-1))
+                logs["val_loss"].append(val_loss.item() / valid_num)
+                logs["val_acc"].append(val_acc / valid_num)
+                logs["step"].append(iter)
             iter+=1
         #print(f'epoch {i} finished!')
         #print(train_acc[iter-1],valid_acc[iter-1])

--- a/task_1/model_training.py
+++ b/task_1/model_training.py
@@ -20,8 +20,7 @@ def linear_warmup_schedule(warmup_steps):#学习率线性warm-up
 
 def transformer_fraction(args,fraction:float=0.5,modulus:int=31,num_sum:int=2,max_opt_times:int=50000,
                          dropout=0.1,noise_ratio:float=0.0,optim_class=torch.optim.AdamW,optim_params={}):
-    device = torch.device("mps" if torch.backends.mps.is_available() 
-                        else "cuda" if torch.cuda.is_available() else "cpu")
+    device = args.device
     #fraction=0.7#训练集占比
     data_num=modulus**num_sum
     train_num=int(data_num*fraction)

--- a/visualize.py
+++ b/visualize.py
@@ -3,12 +3,14 @@ from pathlib import Path
 from matplotlib import pyplot as plt
 import numpy as np
 from seaborn import color_palette
-from typing import Optional, Tuple, List
+from typing import Optional, Any, Tuple, List
 
 def _parse_args():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--log_npz", type=str, required=True)
+    parser.add_argument("--task", type=str, default="main")
+    parser.add_argument("--log_npz", type=str)
     parser.add_argument("--downsample", type=int, default=0)
+    parser.add_argument("--q3_logdir", type=str)
     args = parser.parse_args()
     return args
 
@@ -95,6 +97,82 @@ def main(args: argparse.Namespace):
                 downsample=args.downsample,
             )
 
+def plot_q3_scatter_line(
+    png_file: str,
+    x: np.ndarray,
+    y: np.ndarray,
+    color: Any = None,
+    x_label: Optional[str] = None,
+    y_label: Optional[str] = None,
+    x_ticks: Optional[np.ndarray] = None,
+    y_ticks: Optional[np.ndarray] = None,
+    x_lim: Optional[Tuple[float, float]] = None,
+    y_lim: Optional[Tuple[float, float]] = None,
+    horizonal_lines: bool = False,
+    vertical_lines: bool = False,
+):
+    if color is None:
+        color = color_palette("husl", 1)[0]
+
+    plt.figure(figsize=(6, 3))
+    
+    plt.scatter(x, y, color=color)
+    plt.plot(x, y, color=color)
+    
+    if horizonal_lines and y_ticks is not None:
+        for y_tick in y_ticks:
+            plt.axhline(y=y_tick, color="lightgray", linestyle="-", linewidth=0.8)
+    if vertical_lines and x_ticks is not None:
+        for x_tick in x_ticks:
+            plt.axvline(x=x_tick, color="lightgray", linestyle="-", linewidth=0.8)
+
+    if x_ticks is not None:
+        plt.xticks(x_ticks)
+    if y_ticks is not None:
+        plt.yticks(y_ticks)
+
+    if x_lim is not None:
+        plt.xlim(x_lim)
+    if y_lim is not None:
+        plt.ylim(y_lim)
+    
+    if x_label is not None:
+        plt.xlabel(x_label)
+    if y_label is not None:
+        plt.ylabel(y_label)
+    
+    save_fig(png_file)
+
+def draw_q3(args: argparse.Namespace):
+    workdir = Path(args.q3_logdir)
+    tag = workdir.stem
+    fraction_strs = sorted([file.stem for file in workdir.glob("*.npz")])
+    x = [float(fraction_str) for fraction_str in fraction_strs]
+    y = []
+    for fraction_str in fraction_strs:
+        npz = workdir.joinpath(f"{fraction_str}.npz")
+        with np.load(npz.as_posix()) as data:
+            logs = {key: data[key] for key in data}
+        best_val_acc = logs["val_acc"].max().item()
+        y.append(best_val_acc)
+    plot_q3_scatter_line(
+        workdir.joinpath(f"{tag}.png"),
+        x=x,
+        y=y,
+        color="blue",
+        x_lim=(0, 1),
+        y_lim=(0, 1.05),
+        x_ticks=np.linspace(0, 1, 6),
+        y_ticks=np.linspace(0, 1, 3),
+        horizonal_lines=True,
+        vertical_lines=True,
+    )
+    
 if __name__ == "__main__":
     args = _parse_args()
-    main(args)
+    if args.task == "main":
+        main(args)
+    elif args.task == "q3":
+        draw_q3(args)
+    else:
+        raise NotImplementedError

--- a/visualize.py
+++ b/visualize.py
@@ -167,12 +167,39 @@ def draw_q3(args: argparse.Namespace):
         horizonal_lines=True,
         vertical_lines=True,
     )
+
+def draw_q5(args: argparse.Namespace):
+    log_npz = Path(args.log_npz)
+    with np.load(log_npz.as_posix()) as data:
+        logs = {key: data[key] for key in data}
+    workdir = log_npz.parent.joinpath(log_npz.stem)
+    workdir.mkdir(exist_ok=True)
+
+    steps = logs["step"]
     
+    for key in ["w", "g"]:
+        y1 = logs[f"{key}l1"]
+        y2 = logs[f"{key}l2"]
+        y3 = logs[f"{key}linf"]
+        # y1 = y1 / y1.max()
+        y2 = y2 / y2.max()
+        # y3 = y3 / y3.max()
+        plot_multiple_lines(
+            workdir.joinpath(f"{key}.png"),
+            x=steps,
+            y_list=[logs[f"train_acc"], logs[f"val_acc"], y2],
+            label_list=[f"train_acc", f"val_acc", f"{key}_norm"],
+            downsample=args.downsample,
+        )
+
 if __name__ == "__main__":
     args = _parse_args()
     if args.task == "main":
         main(args)
     elif args.task == "q3":
         draw_q3(args)
+    elif args.task == "q5":
+        main(args)
+        draw_q5(args)
     else:
         raise NotImplementedError

--- a/visualize.py
+++ b/visualize.py
@@ -83,9 +83,8 @@ def main(args: argparse.Namespace):
     workdir = log_npz.parent.joinpath(log_npz.stem)
     workdir.mkdir(exist_ok=True)
 
-    max_step = logs["train_loss"].shape[0]
-    steps = np.arange(max_step) + 1
-    log_steps = np.log10(steps)
+    steps = logs["step"]
+    log_steps = np.log10(steps + 1)
     for key in ["loss", "acc"]:
         for x, tag in zip([steps, log_steps], ["", "_log"]):
             plot_multiple_lines(


### PR DESCRIPTION
- Now log every 10 steps instead of every step by default. This will save ~80% compute.
- args.device now correctly sets device.
- Add q3, q5 related codes and visualizations.